### PR TITLE
introduce @Insert a property decorator for DI

### DIFF
--- a/src/__tests__/integration/insert.test.ts
+++ b/src/__tests__/integration/insert.test.ts
@@ -1,0 +1,124 @@
+import { Singleton, Request } from "@/scopes/scopes";
+import { Insert } from "@/building-blocks/assembler";
+import { strict as assert } from 'node:assert';
+import { Component } from "@/building-blocks/component";
+
+@Singleton
+class TestSingleton {
+    getValue() {
+        return 'singleton-value';
+    }
+}
+
+@Request
+class TestRequest {
+    getValue() {
+        return 'request-value';
+    }
+}
+
+class BaseTestClass {
+
+}
+
+class SingletonTestClass extends BaseTestClass {
+    @Insert(TestSingleton)
+    testSingleton!: TestSingleton;  // Optional - could be undefined
+
+    getSingleton() : TestSingleton | undefined {
+        return this.testSingleton;
+    }
+}
+
+class OptionalSingletonTestClass extends BaseTestClass {
+    @Insert(TestSingleton, true)
+    optionalSingleton!: TestSingleton;  // Optional - could be undefined
+
+    getOptionalSingleton() : TestSingleton | undefined {
+        return this.optionalSingleton;
+    }
+}
+
+class ConstructorInjectionTestClass extends BaseTestClass {
+    singleton: TestSingleton;
+
+    constructor(
+        singleton: TestSingleton
+    ) {
+        super();
+        this.singleton = singleton;
+    }
+
+    getSingleton() : TestSingleton {
+        return this.singleton;
+    }
+}
+
+const testSingletonInsertion = () => {
+    console.log("Test Singleton insertion \n");
+    assert.throws(() => {
+        new SingletonTestClass();
+    }, "Failed to inject SingletonTestClass: No instance of TestSingleton found in application context. Make sure the dependency is decorated with @Singleton or @Request and has been instantiated.");
+    console.log('✅ Throws error if singleton not found and not optional');
+
+    // Create the singleton first
+    const singleton = new TestSingleton() as TestSingleton & Component;
+    console.log("Created singleton:", singleton);
+    const instance = new SingletonTestClass();
+    console.log("Instance:", instance);
+    console.log("Injected singleton:", instance.getSingleton());
+
+    assert.equal(instance.getSingleton(), singleton, "Injected singleton does not match created singleton");
+    console.log('✅ Injected singleton matches created singleton');
+    singleton.stop();
+    console.log("🎉 testSingletonInsertion passed");
+    console.log("================================\n");
+};
+
+const testOptionalSingletonInsertion = () => {
+    console.log("\nTest Optional Singleton insertion \n");
+    const instance = new OptionalSingletonTestClass();
+    console.log("Instance:", instance);
+
+    assert.equal(instance.getOptionalSingleton(), undefined, "Injected optional singleton should be undefined");
+    console.log('✅ Injected optional singleton is undefined');
+
+    const singleton = new TestSingleton() as TestSingleton & Component;
+    const instanceWithSingleton = new OptionalSingletonTestClass();
+    console.log("Instance with singleton:", instanceWithSingleton);
+    console.log("Injected optional singleton:", instanceWithSingleton.getOptionalSingleton());
+    
+    assert.equal(instanceWithSingleton.getOptionalSingleton(), singleton, "Injected optional singleton does not match created singleton");
+    console.log('✅ Injected optional singleton matches created singleton');
+    singleton.stop();
+
+    console.log("🎉 testOptionalSingletonInsertion passed");
+    console.log("================================\n");
+};
+
+(async function main() {
+    try {
+        // Create the singleton first
+        testSingletonInsertion();
+        testOptionalSingletonInsertion();
+
+        // What we want:
+        // const testClass = new TestClass();  // Auto        
+        // Create TestClass - dependency should be auto-injected
+        // const testInstance = new TestClass();
+        
+        // console.log("TestClass instance:", testInstance);
+
+        // const testSingleton = testInstance.getSingleton();
+        // console.log("Injected singleton:", testSingleton);
+
+        // const testRequest = testInstance.getRequest();
+        // console.log("Injected request (should fail outside request context):", testRequest);
+
+        console.log('✅ @Insert decorator works correctly');
+        console.log("🎉 All integration tests passed");
+    } catch (err) {
+        console.error("❌ Integration tests failed:", err);
+        process.exit(1);
+    }
+})();

--- a/src/building-blocks/assembler.ts
+++ b/src/building-blocks/assembler.ts
@@ -36,7 +36,7 @@ type Constructor<T = any> = new (...args: any[]) => T;
  * service.doWork(); // Works! Logger is injected
  */
 const Insert = <T>(type: Constructor<T>, optional: boolean = false) => {
-    return function<This, Value extends T>(
+    return function<This, Value>(
         target: undefined,
         context: ClassFieldDecoratorContext<This, Value>
     ) {

--- a/src/building-blocks/assembler.ts
+++ b/src/building-blocks/assembler.ts
@@ -1,0 +1,6 @@
+import { Component } from "@/building-blocks/component";
+
+
+const Insert = (target: Component) => {
+
+}

--- a/src/building-blocks/assembler.ts
+++ b/src/building-blocks/assembler.ts
@@ -1,6 +1,72 @@
-import { Component } from "@/building-blocks/component";
+import { getApplicationContext } from "@/application-context/application_context";
 
+type Constructor<T = any> = new (...args: any[]) => T; 
 
-const Insert = (target: Component) => {
-
+/**
+ * Property decorator that automatically injects a dependency from the application context.
+ * You must specify the class type to inject.
+ * 
+ * @param type - The constructor/class to inject from the application context
+ * @param optional - If true, returns undefined when not found instead of throwing (default: false)
+ * 
+ * @example
+ * @Singleton
+ * class Logger {
+ *   log(msg: string) { console.log(msg); }
+ * }
+ * 
+ * class MyService {
+ *   @Insert(Logger)
+ *   logger!: Logger;  // Required - will throw if not found
+ *   
+ *   @Insert(Logger, true)
+ *   optionalLogger?: Logger;  // Optional - returns undefined if not found
+ *   
+ *   doWork() {
+ *     this.logger.log('Working...');
+ *     this.optionalLogger?.log('Optional works too!');
+ *   }
+ * }
+ * 
+ * // Create the singleton first
+ * new Logger();
+ * 
+ * // Then use MyService - logger will be auto-injected
+ * const service = new MyService();
+ * service.doWork(); // Works! Logger is injected
+ */
+const Insert = <T>(type: Constructor<T>, optional: boolean = false) => {
+    return function<This, Value extends T>(
+        target: undefined,
+        context: ClassFieldDecoratorContext<This, Value>
+    ) {
+        const fieldName = context.name;
+        
+        // Use addInitializer to eagerly resolve and inject dependency at construction time
+        context.addInitializer(function(this: This) {
+            // Resolve dependency immediately during construction
+            const instance = getApplicationContext(type);
+            
+            if (!instance && !optional) {
+                throw new Error(
+                    `Failed to inject ${String(fieldName)}: No instance of ${type?.name || 'unknown'} found in application context. ` +
+                    `Make sure the dependency is decorated with @Singleton or @Request and has been instantiated.`
+                );
+            }
+            
+            // Cache the resolved instance
+            const cached = (instance as Value) || undefined;
+            
+            // Define property with cached value
+            Object.defineProperty(this, fieldName, {
+                get(): Value | undefined {
+                    return cached;
+                },
+                enumerable: true,
+                configurable: true,
+            });
+        });
+    };
 }
+
+export { Insert };

--- a/src/scopes/scopes.ts
+++ b/src/scopes/scopes.ts
@@ -49,6 +49,13 @@ const Singleton = <T, C extends new(...a:any[]) => T>(Target: C): C => {
     }
   };
 
+  // Set the class name to match the original Target
+  Object.defineProperty(Decorated, 'name', {
+    value: Target.name,
+    writable: false,
+    configurable: true
+  });
+
   // Copy all prototype methods from Target to Decorated
   // This ensures methods defined in Target are available
   Object.getOwnPropertyNames(Target.prototype).forEach(name => {
@@ -152,6 +159,13 @@ const Request = <T, C extends new(...a:any[]) => T>(Target: C): C => {
       setApplicationContext(this as unknown as Component, Decorated as any);
     }
   };
+
+  // Set the class name to match the original Target
+  Object.defineProperty(Decorated, 'name', {
+    value: Target.name,
+    writable: false,
+    configurable: true
+  });
 
   // Copy all prototype methods from Target to Decorated
   Object.getOwnPropertyNames(Target.prototype).forEach(name => {

--- a/src/scopes/scopes.ts
+++ b/src/scopes/scopes.ts
@@ -26,7 +26,7 @@ import {
  * const instance = new MyService() as MyService & Component;
  * instance.getScope(); // Now TypeScript knows about this
  */
-function Singleton<T, C extends new(...a:any[]) => T>(Target: C): C {
+const Singleton = <T, C extends new(...a:any[]) => T>(Target: C): C => {
   // Create a new class that extends SingletonComponent
   const Decorated = class extends SingletonComponent {
     constructor(...args: any[]) {
@@ -131,7 +131,7 @@ function Singleton<T, C extends new(...a:any[]) => T>(Target: C): C {
  * const instance = new UserContext('user-123') as UserContext & Component;
  * instance.getScope(); // Returns 'REQUEST'
  */
-function Request<T, C extends new(...a:any[]) => T>(Target: C): C {
+const Request = <T, C extends new(...a:any[]) => T>(Target: C): C => {
   // Create a new class that extends RequestComponent
   const Decorated = class extends RequestComponent {
     constructor(...args: any[]) {


### PR DESCRIPTION
This pull request introduces a new property decorator for dependency injection, refactors the scope decorators for consistency, and adds a new integration test to verify nested request-scoped component behavior. The main improvements are in dependency injection ergonomics, decorator consistency, and test coverage for request-scoped components.

### Dependency Injection Enhancements
* Added a new `Insert` property decorator in `assembler.ts` to automatically inject dependencies from the application context into class fields, supporting both required and optional injections. This simplifies component wiring and improves code readability. [[1]](diffhunk://#diff-ca82e7890b955f5484d22496d6ad6b48d805c019fdb7c1a137bafedc56d909f0R1-R72) [[2]](diffhunk://#diff-64edf2c3d8a79c9cd160db17395fd6c7aff6a17042e825fb2644335ec1b98f63R6)
* Updated the integration test to use the new `Insert` decorator for injecting `UserContext` and `RequestLogger` into a new `RequestMetadata` request-scoped component.

### Decorator Consistency Improvements
* Refactored the `Singleton` and `Request` scope decorators in `scopes.ts` to use arrow function syntax for consistency and set the decorated class's name to match the original, improving debugging and type inference. [[1]](diffhunk://#diff-bb780999827a9deeea7f2ebbfc71f26ff00b1d630508594d64792f8bc843df41L29-R29) [[2]](diffhunk://#diff-bb780999827a9deeea7f2ebbfc71f26ff00b1d630508594d64792f8bc843df41R52-R58) [[3]](diffhunk://#diff-bb780999827a9deeea7f2ebbfc71f26ff00b1d630508594d64792f8bc843df41L134-R141) [[4]](diffhunk://#diff-bb780999827a9deeea7f2ebbfc71f26ff00b1d630508594d64792f8bc843df41R163-R169)

### Test Coverage
* Added a new `/meta` endpoint and corresponding test (`testNestedRequestScopedComponents`) to verify that nested request-scoped components correctly inject and expose dependencies, ensuring isolation and correctness of request-scoped data. [[1]](diffhunk://#diff-64edf2c3d8a79c9cd160db17395fd6c7aff6a17042e825fb2644335ec1b98f63R166-R179) [[2]](diffhunk://#diff-64edf2c3d8a79c9cd160db17395fd6c7aff6a17042e825fb2644335ec1b98f63R333-R354) [[3]](diffhunk://#diff-64edf2c3d8a79c9cd160db17395fd6c7aff6a17042e825fb2644335ec1b98f63R365)