### PR TITLE
Add Prototype Scope

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,79 @@
-MIT License
+InnoBridge Public License, Version 2.0
 
-Copyright (c) 2025 Yangshun Tay
+Copyright (c) 2025 InnoBridge Technologies and contributors
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+1. Definitions
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+“Software” means the code and related documentation made available under this license.
+“You” / “Your” means the individual or legal entity exercising permissions under this license.
+“Model Provider” means any entity (or its affiliates) whose primary business purpose or a material revenue stream is to develop, train, fine-tune, distill, align, evaluate, host, operate, or sell access to foundation models or other generative AI/LLM/embedding models, or to provide services whose core value is model outputs.
+“Train/Improve” includes pretraining, fine-tuning, domain adaptation, distillation, alignment/safety tuning, RLHF/RLAIF, evaluation/benchmarking used to improve models, dataset/data-pipeline creation or curation for such purposes, inference-time optimization that feeds back into training, or any substantially similar activity.
+“Commercial” means for or directed toward commercial advantage or monetary compensation.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+2. Grant of Permission (MIT-style)
+
+Subject to the conditions below, permission is hereby granted, free of charge, to any person obtaining a copy of the Software to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so.
+
+3. Permitted End-User Commercial Use
+
+End users (including companies whose primary business is not model provision) may build, operate, distribute, and monetize products or services derived from the Software, including products that themselves call third-party AI services, provided they do not act as a Model Provider with respect to those models.
+
+4. Prohibited Uses by Model Providers
+
+Except as expressly permitted in Section 5, Model Providers may not:
+a. use the Software or any derivative works to Train/Improve models;
+b. use the Software to create datasets, evaluation suites, data pipelines, or other assets materially used to Train/Improve models;
+c. incorporate the Software into products or services whose primary purpose is to Train/Improve models for commercial release or sale;
+d. use the Software in any manner designed to circumvent this Section.
+
+This prohibition applies whether or not the resulting models or services directly incorporate the Software’s code.
+
+5. Research Exception (Non-Commercial Academia)
+
+Accredited academic or non-profit research institutions may use the Software to Train/Improve models solely for non-commercial research and publication, provided that (i) any resulting models, datasets, or services are not sold, licensed, or hosted for commercial advantage; and (ii) the Software is acknowledged per Section 7. Use by or for a Model Provider (as contractor, partner, or affiliate) is not covered by this exception.
+
+6. Commercial Exceptions for Model Providers
+
+Model Providers seeking rights beyond Section 4 may request a commercial exception license from InnoBridge Technologies at legal@innobridge.dev
+ (or successor address). Any such exception must be in a signed writing.
+
+7. Attribution & Notice
+
+The above copyright notice and this license text shall be included in all copies or substantial portions of the Software and in documentation for derivative works where practical.
+
+8. Redistribution
+
+Redistributions in source or binary form must retain this license. You may offer warranties, support, or additional terms to your customers for your derivative works, provided they do not purport to alter the rights or obligations of this license for the Software itself.
+
+9. Patents (Limited Grant; Retaliation)
+
+Subject to Sections 4–6, each contributor grants You a perpetual, worldwide, non-exclusive, no-charge, royalty-free patent license to make, use, sell, offer to sell, import, and otherwise practice their contributions as part of the Software.
+If You (or Your affiliate) initiate patent litigation alleging that the Software or a contribution infringes a patent, this patent license terminates as of the filing date.
+
+10. Trademarks
+
+This license does not grant permission to use InnoBridge’s names, logos, or trademarks.
+
+11. Termination
+
+This license terminates automatically if You breach Sections 4 or 7. Upon termination, Your rights under this license cease immediately, but the disclaimers and limitations survive. If You cure a breach within 30 days of notice, Your license is reinstated prospectively at InnoBridge’s discretion.
+
+12. Compliance Assurances
+
+Upon a reasonable, specific, written request alleging a good-faith concern of violation of Section 4, You agree to provide a written assurance describing how You use the Software and confirming compliance. No disclosure of source code, trade secrets, or confidential information is required beyond what is reasonably necessary to address the concern.
+
+13. Warranty Disclaimer
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.
+
+14. Limitation of Liability
+
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+15. Severability; No Waiver
+
+If any provision of this license is unenforceable, the remainder remains in effect. Failure to enforce is not a waiver.
+
+16. Entire Agreement; Versioning
+
+This license is the entire agreement concerning the Software’s licensing terms. InnoBridge may publish new versions with a new version number. If no version is specified in Your distribution, this Version 2.0 applies.

--- a/src/__tests__/integration/prototypescope.test.ts
+++ b/src/__tests__/integration/prototypescope.test.ts
@@ -1,0 +1,94 @@
+import { Prototype } from "@/scopes/scopes";
+import { Component, PrototypeComponent, Scope } from "@/building-blocks/component";
+import { getApplicationContext } from "@/application-context/application_context";
+
+@Prototype
+class DummyPrototype {
+    public readonly label: string;
+    public readonly instanceId: number;
+    private static instanceCount = 0;
+
+    constructor(label = "prototype") {
+        DummyPrototype.instanceCount++;
+        this.instanceId = DummyPrototype.instanceCount;
+        this.label = `${label}-${this.instanceId}`;
+        console.log(`  → DummyPrototype constructor called (instance #${this.instanceId})`);
+    }
+
+    static resetCount() {
+        DummyPrototype.instanceCount = 0;
+    }
+}
+
+const testPrototypeCreatesFreshInstances = () => {
+    console.log("\n📋 Test 1: Prototype decorator returns a fresh instance per construction");
+
+    DummyPrototype.resetCount();
+
+    const instanceA = new DummyPrototype();
+    const instanceB = new DummyPrototype();
+
+    if (instanceA === instanceB) {
+        throw new Error("❌ Prototype decorator returned the same instance");
+    }
+
+    if (instanceA.instanceId !== 1 || instanceB.instanceId !== 2) {
+        throw new Error("❌ Prototype instances did not increment as expected");
+    }
+
+    console.log("✅ Each instantiation produced a new object");
+};
+
+const testPrototypeHasNoContextEntry = () => {
+    console.log("\n📋 Test 2: Prototype instances are not cached in application context");
+
+    DummyPrototype.resetCount();
+    new DummyPrototype();
+
+    const contextInstance = getApplicationContext(DummyPrototype);
+    if (contextInstance !== undefined) {
+        throw new Error("❌ Prototype component should not be resolvable from the context");
+    }
+
+    console.log("✅ getApplicationContext() returns undefined for prototype components");
+};
+
+const testPrototypeExtendsBaseComponents = () => {
+    console.log("\n📋 Test 3: Prototype instance still inherits Component helpers");
+
+    const instance = new DummyPrototype() as DummyPrototype & Component;
+
+    if (!(instance instanceof Component)) {
+        throw new Error("❌ Prototype instance was not recognized as Component");
+    }
+
+    if (!(instance instanceof PrototypeComponent)) {
+        throw new Error("❌ Prototype instance was not recognized as PrototypeComponent");
+    }
+
+    if (instance.getScope() !== Scope.PROTOTYPE) {
+        throw new Error(`❌ Expected scope PROTOTYPE but found ${instance.getScope()}`);
+    }
+
+    // Calling stop() should be a no-op without throwing
+    instance.stop();
+    console.log("✅ Prototype instance exposes Component helpers");
+};
+
+(async function main() {
+    try {
+        console.log("🚀 Starting Prototype Scope Integration Tests\n");
+        console.log("=".repeat(50));
+
+        testPrototypeCreatesFreshInstances();
+        testPrototypeHasNoContextEntry();
+        testPrototypeExtendsBaseComponents();
+
+        console.log("\n" + "=".repeat(50));
+        console.log("🎉 Prototype scope integration tests passed");
+    } catch (err) {
+        console.error("\n" + "=".repeat(50));
+        console.error("❌ Prototype scope integration tests failed:", err);
+        process.exit(1);
+    }
+})();

--- a/src/application-context/application_context.ts
+++ b/src/application-context/application_context.ts
@@ -74,6 +74,9 @@ const setApplicationContext = (instance: Component, constructorRef?: Constructor
             qualifierMap.set(qual, instance);
             break;
         }
+        case Scope.PROTOTYPE:
+            // Prototype instances are intentionally not cached
+            break;
         default:
             throw new Error(`Unsupported scope: ${instance.getScope()}`);
     }
@@ -114,6 +117,9 @@ const getApplicationContext = <T>(className: Constructor<T>, qualifier?: string)
             const qualifierMap = contextSingletonContainer.get(className);
             return qualifierMap?.get(qual) as (T & Component) | undefined;
         }
+        case Scope.PROTOTYPE:
+            // Prototype components are not stored in the context
+            return undefined;
         default:
             throw new Error(`Unsupported scope: ${className.prototype.getScope()}`);
     }
@@ -159,6 +165,9 @@ const removeComponentFromApplicationContext = (className: Constructor, qualifier
             }
             break;
         }
+        case Scope.PROTOTYPE:
+            // Nothing to remove for prototype components
+            break;
         default:
             throw new Error(`Unsupported scope: ${className.prototype.getScope()}`);
     }
@@ -185,6 +194,9 @@ const clearApplicationContext = (scope: Scope): void => {
             if (requestMap) {
                 requestMap.clear();
             }
+            break;
+        case Scope.PROTOTYPE:
+            // Prototype components are not stored centrally
             break;
         default:
             throw new Error(`Unsupported scope: ${scope}`);

--- a/src/building-blocks/component.ts
+++ b/src/building-blocks/component.ts
@@ -2,7 +2,7 @@ import { removeComponentFromApplicationContext, setApplicationContext } from '@/
 
 enum Scope {
   SINGLETON = 'SINGLETON',
-  TRANSIENT = 'TRANSIENT',
+  PROTOTYPE = 'PROTOTYPE',
   REQUEST = 'REQUEST'
 };
 
@@ -41,6 +41,17 @@ class SingletonComponent extends Component {
   }
 };
 
+class PrototypeComponent extends Component {
+  constructor(args?: any) {
+    super();
+    this.setScope(Scope.PROTOTYPE);
+  }
+
+  getScope(): Scope | undefined {
+    return Scope.PROTOTYPE;
+  }
+};
+
 class RequestComponent extends Component {
   constructor(args?: any) {
     super();
@@ -55,6 +66,7 @@ class RequestComponent extends Component {
 export {
     Component,
     SingletonComponent,
+    PrototypeComponent,
     RequestComponent,
     Scope
 };


### PR DESCRIPTION
This pull request introduces a new `@Prototype` decorator to the dependency injection framework, enabling classes to be constructed as fresh instances on every invocation while still benefiting from container-managed wiring and lifecycle helpers. The implementation ensures prototype-scoped components are never cached or stored in the application context, and updates documentation and tests to reflect this new feature.

**Prototype Scope Feature**

* Added `@Prototype` decorator in `src/scopes/scopes.ts`, which ensures decorated classes are instantiated anew each time and are not cached in the application context. Decorated instances inherit from `PrototypeComponent` for lifecycle helpers. [[1]](diffhunk://#diff-bb780999827a9deeea7f2ebbfc71f26ff00b1d630508594d64792f8bc843df41R97-R158) [[2]](diffhunk://#diff-bb780999827a9deeea7f2ebbfc71f26ff00b1d630508594d64792f8bc843df41R5) [[3]](diffhunk://#diff-90f5db30461e61d633d88e3753604e9a210364146eb0c50a6cfdc14bed67334cR44-R54) [[4]](diffhunk://#diff-90f5db30461e61d633d88e3753604e9a210364146eb0c50a6cfdc14bed67334cL5-R5)
* Updated the context management logic in `src/application-context/application_context.ts` to bypass caching, retrieval, and removal for prototype-scoped components. [[1]](diffhunk://#diff-79c87d390707ac1e8694d22dac1edf3f44c857a26d2126bb9d4a9ff4243ff39fR77-R79) [[2]](diffhunk://#diff-79c87d390707ac1e8694d22dac1edf3f44c857a26d2126bb9d4a9ff4243ff39fR120-R122) [[3]](diffhunk://#diff-79c87d390707ac1e8694d22dac1edf3f44c857a26d2126bb9d4a9ff4243ff39fR168-R170) [[4]](diffhunk://#diff-79c87d390707ac1e8694d22dac1edf3f44c857a26d2126bb9d4a9ff4243ff39fR198-R200)

**Documentation Updates**

* Expanded `README.md` to describe the `@Prototype` decorator, its use cases, and how it differs from singleton and request scopes. Updated diagrams, cache explanations, and lifecycle method documentation to include prototype scope. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R10) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R46-R96) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R161-R162) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L146-R200) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R220-R221) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R286-R287) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R374)

**Testing**

* Added integration tests in `src/__tests__/integration/prototypescope.test.ts` to verify that prototype-scoped components are never cached, always produce fresh instances, and correctly inherit lifecycle helpers.

**Component Infrastructure**

* Introduced `PrototypeComponent` class in `src/building-blocks/component.ts` for prototype-scoped components, updated `Scope` enum, and adjusted exports accordingly. [[1]](diffhunk://#diff-90f5db30461e61d633d88e3753604e9a210364146eb0c50a6cfdc14bed67334cR44-R54) [[2]](diffhunk://#diff-90f5db30461e61d633d88e3753604e9a210364146eb0c50a6cfdc14bed67334cL5-R5) [[3]](diffhunk://#diff-90f5db30461e61d633d88e3753604e9a210364146eb0c50a6cfdc14bed67334cR69)

**License Update**

* Changed the project license from MIT to InnoBridge Public License v2.0, restricting model providers from using the software for model training/improvement except under specific conditions.