### PR TITLE
expose application context apis

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innobridge/memoizedsingleton",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A TypeScript library for Dependency Injection",
   "author": "yilengyao <innobridgetechnology@gmail.com>",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,37 @@
-import * as scopes from '@/scopes/scopes';
-import * as component from '@/building-blocks/component';
+import { Singleton, Prototype, Request } from '@/scopes/scopes';
+import { Component, SingletonComponent, RequestComponent, PrototypeComponent, Scope } from '@/building-blocks/component';
 import { RequestMetadata } from '@/components/request_metadata';
 import { UserMetadata } from '@/components/user_metadata';
 import { Authentication, AuthenticationMethod } from '@/components/authentication';
 import { Config, getConfig } from '@/components/config';
+import {
+    initializeRequestContext,
+    setApplicationContext,
+    getApplicationContext,
+    removeComponentFromApplicationContext,
+    clearApplicationContext,
+    hasRequestContext
+} from '@/application-context/application_context';
 
 export {
-    scopes,
-    component,
+    Singleton,
+    Prototype,
+    Request,
+    Component,
+    SingletonComponent,
+    RequestComponent,
+    PrototypeComponent,
+    Scope,
     RequestMetadata,
     UserMetadata,
     Authentication,
     AuthenticationMethod,
+    initializeRequestContext,
+    setApplicationContext,
+    getApplicationContext,
+    removeComponentFromApplicationContext,
+    clearApplicationContext,
+    hasRequestContext,
     Config,
     getConfig
 };


### PR DESCRIPTION
This pull request updates the package version and refines the main export interface in `src/index.ts` to provide more direct and granular exports for scopes, components, and application context utilities. This improves clarity and usability for consumers of the library.

**Export interface improvements:**

* Replaced wildcard imports/exports for `scopes` and `component` with named exports for `Singleton`, `Prototype`, `Request`, `Component`, `SingletonComponent`, `RequestComponent`, `PrototypeComponent`, and `Scope` in `src/index.ts`, making the API more explicit and easier to use.
* Added direct exports for application context utilities like `initializeRequestContext`, `setApplicationContext`, `getApplicationContext`, `removeComponentFromApplicationContext`, `clearApplicationContext`, and `hasRequestContext` to `src/index.ts`, improving access to context management functions.

**Version update:**

* Bumped package version from `0.0.3` to `0.0.4` in `package.json` to reflect the new exports and interface changes.