### PR TITLE
expose @Insert

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innobridge/memoizedsingleton",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A TypeScript library for Dependency Injection",
   "author": "yilengyao <innobridgetechnology@gmail.com>",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
     clearApplicationContext,
     hasRequestContext
 } from '@/application-context/application_context';
+import { Insert } from '@/building-blocks/assembler';
 
 export {
     Singleton,
@@ -33,5 +34,6 @@ export {
     clearApplicationContext,
     hasRequestContext,
     Config,
-    getConfig
+    getConfig,
+    Insert
 };


### PR DESCRIPTION
This pull request introduces a minor version bump and updates the public API for the `@innobridge/memoizedsingleton` package. The most notable change is the addition of the `Insert` export from the `assembler` module.

**Versioning and API updates:**

* Bumped the package version from `0.0.4` to `0.0.5` in `package.json` to reflect the new export.
* Added `Insert` to the exports in `src/index.ts`, making it available for consumers of the package. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R15) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L36-R38)